### PR TITLE
enable contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ Example changelog.xml (if you place your schema changelogs in `conf/liquibase/sc
 </databaseChangeLog>
 ```
 
+### Using contexts
+
+Liquibase contexts can be used to maintain a different set of change sets for different environments or uses.  For example, you may have one set to maintain the production schema 
+and one set to maintain the test schema, along with a small set of test data
+
+Context is an attribute of the change set
+```xml
+<changeSet id="2" author="bob" context="test">
+        ...
+</changeSet>
+```
+
+To run the "test" context only, add to your liquibase configuration in application.conf
+```
+contexts = ["test"]
+```
+
 ### Disabling Liquibase migrations
 
 To disable running Liquibase on startup, you can set

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Context is an attribute of the change set
 
 To run the "test" context only, add to your liquibase configuration in application.conf
 ```
-contexts = ["test"]
+liquibase.contexts = ["test"]
 ```
 
 ### Disabling Liquibase migrations

--- a/src/main/scala/com/ticketfly/play/liquibase/PlayLiquibaseModule.scala
+++ b/src/main/scala/com/ticketfly/play/liquibase/PlayLiquibaseModule.scala
@@ -37,6 +37,8 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
 
   private final val log = Logger(classOf[PlayLiquibase])
 
+  private val contexts = config.getStringList("liquibase.contexts").map(l => new Contexts(l)).getOrElse(new Contexts())
+
   // Constructor
   upgradeSchema(config.getString("app.version"))
 
@@ -49,7 +51,7 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
     liquibase() match {
       case Some(lb) =>
         log.info("Running liquibase migrations")
-        lb.update(new Contexts())
+        lb.update(contexts)
         tag.foreach(t => lb.tag(t))
       case None =>
     }
@@ -62,7 +64,7 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
   def showSql (): Unit = liquibase().foreach {
     lb =>
       val writer = new StringWriter()
-      lb.update(new Contexts(), writer)
+      lb.update(contexts, writer)
       log.info(writer.toString)
   }
 
@@ -73,7 +75,7 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
    * @return true if there are pending changes
    */
   def needsUpgrade: Boolean = liquibase().exists { lb =>
-    val unrunChanges = lb.listUnrunChangeSets(new Contexts(), new LabelExpression()).asScala
+    val unrunChanges = lb.listUnrunChangeSets(contexts, new LabelExpression()).asScala
     unrunChanges.foreach {
       change => log.warn(s"Unrun changeset: ${change.getId}, s{change.getAuthor}, ${change.getDescription}, ${change.getComments}")
     }


### PR DESCRIPTION
allows optional use of contexts by adding to liquibase config like

contexts = ["all", "test"]