### PR TITLE
load files from classpath if path is prepended with classpath:

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ To run the "test" context only, add to your liquibase configuration in applicati
 liquibase.contexts = ["test"]
 ```
 
+
+### Loading changes from the classpath
+
+If your database access code is in a sub-module or library, you may want to keep your change files in, for example, src/main/resources/liquibase of that library.  In this case you can choose to load
+your files from the classpath by specifying the changelog attribute and prepending 'classpath:' to the path.  In the scenario where your master.xml file is located in src/main/resources/liquibase,
+add to your liquibase configuration
+```
+liquibase.changelog = "classpath:liquibase/master.xml"
+```
+
 ### Disabling Liquibase migrations
 
 To disable running Liquibase on startup, you can set

--- a/src/main/scala/com/ticketfly/play/liquibase/PlayLiquibaseModule.scala
+++ b/src/main/scala/com/ticketfly/play/liquibase/PlayLiquibaseModule.scala
@@ -111,7 +111,7 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
         username    <- usernameOpt
         password    <- passwordOpt
         driver      <- driverOpt
-        changelog   <- changelogOpt
+        changelogTemp   <- changelogOpt
         database          = CommandLineUtils.createDatabaseObject(
           new ClassLoaderResourceAccessor(environment.classLoader),
           url,
@@ -134,7 +134,8 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
         // the jar and in the dist zip directory. And both are on classpath.
         // Liquibase throws:
         // liquibase.exception.ChangeLogParseException: Error Reading Migration File: Found 2 files that match liquibase/changelog.xml
-        resourceAccessor  = new FileSystemResourceAccessor(environment.rootPath.getPath)
+        resourceAccessor  = if(changelogTemp.startsWith("classpath:")) new ClassLoaderResourceAccessor() else new FileSystemResourceAccessor(environment.rootPath.getPath)
+        changelog = changelogTemp.replaceFirst("classpath:", "")
       } yield new Liquibase(changelog, resourceAccessor, database)
 
       if(liquibaseOpt.isEmpty) {


### PR DESCRIPTION
the scenario this is meant to address is

data access code and unit tests, dependent on liquibase in a library or sub-module
play app dependent on that library

liquibase files will be in the library jar file and can be run by the plugin from the classpath