### PR TITLE
Added support for liquibase parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,28 +47,42 @@ to eagerly run migrations on startup.
 
 ## Configuration
 
-Add to `application.conf`:
+If only one jdbc connection is defined, that is used by default, no additional configuration needed. E.g. 
+```
+db.default {
+    url      = "jdbc:mysql://localhost/myschema"
+    driver   = "com.mysql.jdbc.Driver"
+}
+```
 
+Otherwise add to `application.conf`:
 ```
 liquibase {
     url      = "jdbc:mysql://localhost/myschema?logger=com.mysql.jdbc.log.Slf4JLogger"
     driver   = "com.mysql.jdbc.Driver"
-    user     = "ticketfly"
+    username = "ticketfly"
     password = "bar123"
 }
-
 ```
 
 If you are using Slick with Play, you can reference Slick config:
-
 ```
 liquibase = ${slick.dbs.default.db}
 ```
 
+Supported optional [liquibase configuration parameters](http://www.liquibase.org/documentation/config_properties.html
+):  
+_changelog, contexts, defaultCatalogName, defaultSchemaName, databaseClass, driverPropertiesFile,
+propertyProviderClass, liquibaseCatalogName, liquibaseSchemaName, 
+databaseChangeLogTableName, databaseChangeLogLockTableName_
+
+To disable liquibase execution set `liquibase.enable=false`
+
+__Note:__ Required parameters are: `url, driver`
 
 ## Using Liquibase
 
-Liquibase Module uses Liquibase 3.6.2
+Liquibase Module works with Liquibase 3.6+
 
 Example changelog.xml:
 
@@ -221,8 +235,6 @@ After setting your credentials, you can do:
 sbt +publishSigned
 sbt sonatypeReleaseAll
 ```
-
-
 
 ## Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ to eagerly run migrations on startup.
 
 | Play      | Scala        | play-liquibase |
 | ----------| -------------| -------------- |
-| 2.4-2.5   | 2.10 - 2.11  | 1.5            |
-| 2.6       | 2.11 - 2.12  | 2.0            |
+| 2.4 - 2.5 | 2.10 - 2.11  | 1.6            |
+| 2.6       | 2.11 - 2.12  | 2.1            |
 
 ## Configuration
 

--- a/play-liquibase/build.sbt
+++ b/play-liquibase/build.sbt
@@ -21,6 +21,7 @@ val playVersion = "2.6.5"
 libraryDependencies ++= Seq(
   "org.liquibase" % "liquibase-core" % "3.6.2",
   "com.mattbertolini" % "liquibase-slf4j" % "2.0.0",
+  "com.typesafe.play" %% "play-jdbc" % playVersion % Provided,
   "com.typesafe.play" %% "play" % playVersion % Provided,
   "javax.inject" % "javax.inject" % "1" % Provided
 )

--- a/play-liquibase/build.sbt
+++ b/play-liquibase/build.sbt
@@ -2,7 +2,7 @@ organization := "com.ticketfly"
 
 name := "play-liquibase"
 
-version := "2.1"
+version := "2.2-SNAPSHOT"
 
 homepage := Some(url("https://github.com/Ticketfly/play-liquibase"))
 

--- a/play-liquibase/src/main/scala/com/ticketfly/play/liquibase/PlayLiquibaseModule.scala
+++ b/play-liquibase/src/main/scala/com/ticketfly/play/liquibase/PlayLiquibaseModule.scala
@@ -1,15 +1,20 @@
 package com.ticketfly.play.liquibase
 
 import java.io.StringWriter
-import javax.inject.Singleton
+import java.net.URLClassLoader
 
+import javax.inject.{Inject, Singleton}
 import liquibase.integration.commandline.CommandLineUtils
 import liquibase.resource.{ClassLoaderResourceAccessor, FileSystemResourceAccessor}
+import liquibase.servicelocator.ServiceLocator
 import liquibase.{Contexts, LabelExpression, Liquibase}
 import play.api._
-import play.api.inject.{Binding, Module}
+import play.api.db.{DBApi, DatabaseConfig, DefaultDatabase}
+import play.api.inject._
 
+import scala.language.implicitConversions
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 /**
  * Play Liquibase module. Automatically runs Liquibase migrations on Play app startup.
@@ -25,38 +30,38 @@ import scala.collection.JavaConverters._
  */
 class PlayLiquibaseModule extends Module {
 
-  override def bindings (environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     // eagerly bind module so it runs on Play startup
-    bind[PlayLiquibase].to(new PlayLiquibase(environment, configuration)).eagerly()
+    bind[PlayLiquibase].toSelf.eagerly()
   )
-
 }
 
 @Singleton
-class PlayLiquibase(environment: Environment, config: Configuration) {
+class PlayLiquibase @Inject()(environment: Environment, config: Configuration, injector: Injector) {
+  private val log = Logger(classOf[PlayLiquibase])
+  val enableLiquibase: Boolean = config.getOptional[Boolean](Param.liquibase + "." + Param.enable).getOrElse(true)
+  if (enableLiquibase) {
+    // Constructor
+    upgradeSchema(config.getOptional[String]("app.version"))
+  } else {
+    log.info("Liquibase is disabled. No migrations will be run")
+  }
 
-  private final val log = Logger(classOf[PlayLiquibase])
-
-  private val contexts = config.getStringList("liquibase.contexts").map(l => new Contexts(l)).getOrElse(new Contexts())
-
-  // Constructor
-  upgradeSchema(config.getString("app.version"))
+  lazy val contexts: Contexts = config.getOptional[Seq[String]](Param.liquibase + ".contexts").fold(new Contexts())(l
+  => new Contexts(l.asJava))
 
   /**
    * Run Liquibase schema upgrade
    *
    * @param tag Optionally tag schema version
    */
-  def upgradeSchema (tag: Option[String] = None): Unit = {
-    liquibase() match {
-      case Some(lb) =>
+  def upgradeSchema (tag: Option[String] = None): Unit =
+    liquibase() foreach {
+      lb =>
         log.info("Running liquibase migrations")
         lb.update(contexts)
         tag.foreach(t => lb.tag(t))
-      case None =>
     }
-  }
-
 
   /**
    * Show pending schema changes in the log but don't run them.
@@ -68,86 +73,152 @@ class PlayLiquibase(environment: Environment, config: Configuration) {
       log.info(writer.toString)
   }
 
-
   /**
    * Check if there are pending schema changes.
    *
    * @return true if there are pending changes
    */
-  def needsUpgrade: Boolean = liquibase().exists { lb =>
-    val unrunChanges = lb.listUnrunChangeSets(contexts, new LabelExpression()).asScala
-    unrunChanges.foreach {
-      change => log.warn(s"Unrun changeset: ${change.getId}, ${change.getAuthor}, ${change.getDescription}, ${change.getComments}")
-    }
-    unrunChanges.nonEmpty
+  def needsUpgrade: Boolean = liquibase().exists {
+    lb =>
+      val unrunChanges = lb.listUnrunChangeSets(contexts, new LabelExpression()).asScala
+      unrunChanges.foreach {
+        change => log.warn(s"Unrun changeset: ${change.getId}, ${change.getAuthor}, ${change.getDescription}, ${change.getComments}")
+      }
+      unrunChanges.nonEmpty
   }
-
 
   /**
    * Force unlock Liquibase tables
    */
-  def unlock (): Unit = liquibase().foreach {
+  def unlock(): Unit = liquibase().foreach {
     lb =>
       log.info("Releasing liquibase locks")
       lb.forceReleaseLocks()
   }
 
+  type Param = Param.Value
 
-  protected def liquibase(): Option[Liquibase] = {
+  object Param extends Enumeration {
+    val contexts,
+		 enable,
+		 changelog,
+		 url,
+		 driver,
+		 user,
+		 password,
+		 defaultCatalogName,
+		 defaultSchemaName,
+		 databaseClass,
+		 driverPropertiesFile,
+		 propertyProviderClass,
+		 liquibaseCatalogName,
+		 liquibaseSchemaName,
+		 databaseChangeLogTableName,
+		 databaseChangeLogLockTableName = Value
 
-    val liquibaseConfOpt = config.getConfig("liquibase")
+    implicit def toStr(v: Param): String = v.toString
 
-    val enableLiquibase = liquibaseConfOpt.flatMap(_.getBoolean("enable")).getOrElse(true)
-
-    val urlOpt          = liquibaseConfOpt.flatMap(_.getString("url"))
-    val driverOpt       = liquibaseConfOpt.flatMap(_.getString("driver"))
-    val usernameOpt     = liquibaseConfOpt.flatMap(_.getString("user"))
-    val passwordOpt     = liquibaseConfOpt.flatMap(_.getString("password"))
-    val changelogOpt    = liquibaseConfOpt.flatMap(_.getString("changelog"))
-
-    if (enableLiquibase) {
-      val liquibaseOpt = for {
-        url         <- urlOpt
-        username    <- usernameOpt
-        password    <- passwordOpt
-        driver      <- driverOpt
-        changelogTemp   <- changelogOpt
-        database          = CommandLineUtils.createDatabaseObject(
-          new ClassLoaderResourceAccessor(environment.classLoader),
-          url,
-          username,
-          password,
-          driver,
-          null,   // defaultCatalogName
-          null,   // defaultSchemaName
-          false,  // outputDefaultCatalog,
-          false,  // outputDefaultSchema,
-          null,   // databaseClass,
-          null,   // driverPropertiesFile,
-          null,   // propertyProviderClass,
-          null,   // liquibaseCatalogName,
-          null,   // liquibaseSchemaName,
-          null,   // databaseChangeLogTableName
-          null    // databaseChangeLogLockTableName
-        )
-
-        resourceAccessor  = if(changelogTemp.startsWith("classpath:")) {
-          new ClassLoaderResourceAccessor(environment.classLoader)
-        } else {
-          new FileSystemResourceAccessor(environment.rootPath.getPath)
-        }
-        changelog = changelogTemp.replaceFirst("classpath:", "")
-      } yield new Liquibase(changelog, resourceAccessor, database)
-
-      if(liquibaseOpt.isEmpty) {
-        log.warn("Liquibase is not configured")
-      }
-
-      liquibaseOpt
-    } else {
-      log.info("Liquibase is disabled. No migrations will be run")
-      None
-    }
+    val classpathPrefix = "classpath:"
+    val liquibase = "liquibase"
   }
 
+  /** get p parameter from cfg.
+	  * If not found use defValue
+	  *
+	  * @param p      parameter get value for
+	  * @param defValue  default value
+	  * @param cfg       configuration the value shall be taken from
+	  * @return null if not set or trimmed to an empty string (null is required for liquibase)
+	  */
+	 def getParam(p: Param, defValue: Option[String] = None)
+	             (implicit cfg: Option[Configuration]): String = {
+	   cfg.flatMap(_.getOptional[String](p))
+	      .orElse(defValue)
+	      .collect { case x if x.trim.nonEmpty => x }
+	      .orNull
+	 }
+
+  protected def liquibase(): Option[Liquibase] = {
+    var missingRequiredParam = false
+
+    /** get p parameter from cfg.
+     * If not found use defValue
+     *
+     * @param p         parameter get value for
+     * @param defValue  default value
+     * @param cfg       configuration the value shall be taken from
+     * @return null if not set or trimmed to an empty string
+     */
+    def getRequiredParam(p: Param, defValue: Option[String] = None)
+                        (implicit cfg: Option[Configuration]): String = {
+      val ret = getParam(p, defValue)(cfg)
+      if (null == ret) {
+        missingRequiredParam = true
+        log.warn(s"Missing required configuration parameter: $p")
+      }
+      ret
+    }
+
+    implicit val liquibaseConfOpt: Option[Configuration] = config.getOptional[Configuration]("liquibase")
+
+    val dbCfg = singleJdbcDatabaseConfig
+
+    val url = getRequiredParam(Param.url, dbCfg.flatMap(_.url))
+    val driver = getRequiredParam(Param.driver, dbCfg.flatMap(_.driver))
+
+    if (missingRequiredParam) {
+      log.warn("Liquibase is not configured properly! See previous logs")
+      None
+    }
+    else {
+      val threadClsLoader = Thread.currentThread.getContextClassLoader
+
+      val urls = Array("liquibase.Liquibase", driver).map {
+        Class.forName(_).getProtectionDomain.getCodeSource.getLocation
+      }
+
+      val cl = new URLClassLoader(urls, threadClsLoader)
+      ServiceLocator.getInstance().setResourceAccessor(new ClassLoaderResourceAccessor(cl))
+
+      val changelog = getParam(Param.changelog, Some("conf/liquibase/changelog.xml"))
+
+      val database = CommandLineUtils.createDatabaseObject(
+        new ClassLoaderResourceAccessor(cl),
+        url,
+        getParam(Param.user, dbCfg.flatMap(_.username)),
+        getParam(Param.password, dbCfg.flatMap(_.password)),
+        driver,
+        getParam(Param.defaultCatalogName),
+        getParam(Param.defaultSchemaName),
+        false, // outputDefaultCatalog,
+        false, // outputDefaultSchema,
+        getParam(Param.databaseClass),
+        getParam(Param.driverPropertiesFile),
+        getParam(Param.propertyProviderClass),
+        getParam(Param.liquibaseCatalogName),
+        getParam(Param.liquibaseSchemaName),
+        getParam(Param.databaseChangeLogTableName),
+        getParam(Param.databaseChangeLogLockTableName)
+      )
+
+      val resourceAccessor = if (changelog.startsWith(Param.classpathPrefix)) {
+        new ClassLoaderResourceAccessor(environment.classLoader)
+      } else {
+        new FileSystemResourceAccessor(environment.rootPath.getPath)
+      }
+      Some(new Liquibase(changelog.replaceFirst(Param.classpathPrefix, ""), resourceAccessor, database))
+    }
+  }
+	/** Get the db parameters from the configuration if only one is defined */
+  protected def singleJdbcDatabaseConfig: Option[DatabaseConfig]  = {
+    Try(injector.instanceOf(classOf[DBApi])).toOption.map { dbApi =>
+      val dbs = dbApi.databases
+      if (dbs.length == 1) {
+        dbs.head match {
+          case db: DefaultDatabase => db.databaseConfig
+          case _ => null
+        }
+      } else null
+    }
+  }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18


### PR DESCRIPTION
* Added support for liquibase parameters: defaultCatalogName, defaultSchemaName, databaseClass, driverPropertiesFile, propertyProviderClass, liquibaseCatalogName, liquibaseSchemaName, databaseChangeLogTableName, databaseChangeLogLockTableName
* Scan liquibase packages only in liquibase.jar -> Much quicker (4x) load time
* Get DBApi db parameters by default from the configuration, if there is only one defined